### PR TITLE
Show given date

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ init(
     appearance: Appearance = .default, 
     minimumDate: Date? = nil, 
     maximumDate: Date? = nil, 
+    startDate: Date? = nil,
     locale: Locale? = nil
 )
 ```
-The standard initializer lets you specify the first day of the week, appearance, optional minimum and maximum dates, and the locale, although it provides sensible defaults for all of these.
+The standard initializer lets you specify the first day of the week, appearance, optional minimum and maximum dates, start date of the calendar and the locale, although it provides sensible defaults for all of these.
 
 `CalendarPicker` has an additional initializer:
 

--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -42,6 +42,9 @@ public struct CalendarView {
         }
     }
     
+    /// Start date (if any)
+    public var startDate: Date?
+    
     /// Calendar appearance
     public var appearance: CalendarPicker.Appearance {
         get {
@@ -91,19 +94,23 @@ public struct CalendarView {
     ///   - appearance: appearance of calendar view. Default is `Appearance.default`.
     ///   - minimumDate: minimum date to enable. Default is `nil`.
     ///   - maximumDate: maximum date to enable. Default is `nil`.
+    ///   - startDate: start date of the calendar. Default is `nil`.
     ///   - locale: locale for data formatting e.g Date format. Default is `nil`.
     public init(
         firstWeekday: Int? = nil,
         appearance: CalendarPicker.Appearance = .default,
         minimumDate: Date? = nil,
         maximumDate: Date? = nil,
+        startDate: Date? = nil,
         locale: Locale? = nil
+        
     ) {
         self.firstWeekday = firstWeekday ?? (Locale.current.calendar.firstWeekday - 1)
         self.appearance = appearance
         self.minimumDate = minimumDate?.dateOnly
         self.maximumDate = maximumDate?.dateOnly
         self.locale = locale ?? Locale.current
+        self.startDate = startDate
     }
 }
 
@@ -120,6 +127,11 @@ extension CalendarView: View {
             })
         )
         .background(Color(self.appearance.backgroundColor))
+        .onAppear(perform: {
+            if let getStartDate = self.startDate {
+                currentDate = getStartDate
+            }
+        })
     }
     
     @ViewBuilder

--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -103,7 +103,6 @@ public struct CalendarView {
         maximumDate: Date? = nil,
         startDate: Date? = nil,
         locale: Locale? = nil
-        
     ) {
         self.firstWeekday = firstWeekday ?? (Locale.current.calendar.firstWeekday - 1)
         self.appearance = appearance

--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -109,7 +109,7 @@ public struct CalendarView {
         self.minimumDate = minimumDate?.dateOnly
         self.maximumDate = maximumDate?.dateOnly
         self.locale = locale ?? Locale.current
-        self.startDate = startDate
+        self.startDate = startDate?.startDateOfMonth()
     }
 }
 

--- a/Sources/YCalendarPicker/UIKit/CalendarPicker.swift
+++ b/Sources/YCalendarPicker/UIKit/CalendarPicker.swift
@@ -58,12 +58,14 @@ public class CalendarPicker: UIControl {
     ///   - appearance: appearance for the calendar. Default is `.default`.
     ///   - minimumDate: minimum selectable date. Default is `nil`.
     ///   - maximumDate: maximum selectable date. Default is `nil`.
+    ///   - startDate: start date of the calendar. Default is `nil`.
     ///   - locale: locale for date formatting. Pass `nil` to use current locale. Default is `nil`.
     public required init(
         firstWeekday: Int? = nil,
         appearance: Appearance = .default,
         minimumDate: Date? = nil,
         maximumDate: Date? = nil,
+        startDate: Date? = nil,
         locale: Locale? = nil
     ) {
         calendarView = CalendarView(
@@ -71,6 +73,7 @@ public class CalendarPicker: UIControl {
             appearance: appearance,
             minimumDate: minimumDate,
             maximumDate: maximumDate,
+            startDate: startDate,
             locale: locale
         )
         super.init(frame: .zero)
@@ -83,6 +86,7 @@ public class CalendarPicker: UIControl {
             appearance: Appearance(),
             minimumDate: nil,
             maximumDate: nil,
+            startDate: nil,
             locale: nil
         )
         super.init(coder: coder)

--- a/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
+++ b/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
@@ -178,9 +178,10 @@ final class CalendarViewTests: XCTestCase {
     }
     
     func testOnStartDate() {
-        let sut = makeSUT(startDate: Date().date(byAddingMonth: 4))
+        let expectedDate = Date().date(byAddingMonth: 4)
+        let sut = makeSUT(startDate: expectedDate)
         XCTAssertNotNil(sut.startDate)
-        XCTAssertNotEqual(sut.currentDate, sut.startDate)
+        XCTAssertEqual(expectedDate?.startDateOfMonth(), sut.startDate)
     }
     
     func testCalendarViewPreviewIsNotNill() {

--- a/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
+++ b/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
@@ -177,6 +177,12 @@ final class CalendarViewTests: XCTestCase {
         XCTAssertNil(sut.date)
     }
     
+    func testOnStartDate() {
+        let sut = makeSUT(startDate: Date().date(byAddingMonth: 4))
+        XCTAssertNotNil(sut.startDate)
+        XCTAssertNotEqual(sut.currentDate, sut.startDate)
+    }
+    
     func testCalendarViewPreviewIsNotNill() {
         XCTAssertNotNil(CalendarView_Previews.previews)
     }
@@ -190,12 +196,14 @@ private extension CalendarViewTests {
     func makeSUT(
         firstWeekday: Int? = nil,
         minimumDate: Date? = nil,
-        maximumDate: Date? = nil
+        maximumDate: Date? = nil,
+        startDate: Date? = nil
     ) -> CalendarView {
         let sut = CalendarView(
             firstWeekday: firstWeekday ?? 0,
             minimumDate: minimumDate,
-            maximumDate: maximumDate
+            maximumDate: maximumDate,
+            startDate: startDate
         )
         XCTAssertNotNil(sut.body)
         return sut


### PR DESCRIPTION
## Introduction ##
Show Date month 

## Purpose ##
- FIX - #21 
- We should allow a user to show the given date month.

## Scope ##

we have introduced a new property startDate in which user can add the date and will show the given date month on calendar.

## 📈 Coverage ##

##### Code #####
<img width="1391" alt="Screenshot 2023-12-11 at 5 10 45 PM" src="https://github.com/codeandtheory/ycalendarpicker-ios/assets/102538361/e682ae72-b2b5-4c0a-8e19-3c5ec8005445">


##### Documentation #####
<img width="802" alt="Screenshot 2023-12-11 at 5 13 02 PM" src="https://github.com/codeandtheory/ycalendarpicker-ios/assets/102538361/2fcc3fca-d028-42c6-9641-563c0eeb2cc6">

